### PR TITLE
Fix prompt newline in ChatAssistant

### DIFF
--- a/retrieval_chat-upgrade3.py
+++ b/retrieval_chat-upgrade3.py
@@ -9,6 +9,7 @@ import numpy as np
 import pandas as pd
 from sklearn.metrics.pairwise import cosine_similarity
 import re
+import textwrap
 
 
 class Retriever:
@@ -58,18 +59,20 @@ class ChatAssistant:
         if not context_chunks:
             return "No relevant context found."
         context = "\n\n".join(context_chunks)
-        prompt = f"""
-You are a reasoning assistant. Use the provided context to compute and explain your answer step by step.
-If the answer requires math, show logical estimates.
+        prompt = textwrap.dedent(
+            f"""\
+            You are a reasoning assistant. Use the provided context to compute and explain your answer step by step.
+            If the answer requires math, show logical estimates.
 
-[Context]
-{context}
+            [Context]
+            {context}
 
-[User Question]
-{query}
+            [User Question]
+            {query}
 
-[Answer]
-"""
+            [Answer]
+            """
+        )
         resp = httpx.post(
             f"{self.base_url}/v1/chat/completions",
             json={


### PR DESCRIPTION
## Summary
- avoid leading newline in `ChatAssistant.answer` prompt using `textwrap.dedent`
- add `textwrap` import

## Testing
- `python -m py_compile retrieval_chat-upgrade3.py`

------
https://chatgpt.com/codex/tasks/task_e_685aedb37d90832fbda45fea04d013cb